### PR TITLE
Add /generate-flyer endpoint

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1,4 +1,5 @@
-from flask import jsonify
+from flask import jsonify, request
+from .utils.openai_client import generate_flyer
 
 from . import app
 
@@ -6,3 +7,28 @@ from . import app
 @app.route('/')
 def index():
     return jsonify({'message': 'Hello, World!'})
+
+
+@app.route('/generate-flyer', methods=['POST'])
+def generate_flyer_route():
+    """Generate an email flyer based on property details."""
+    data = request.get_json(silent=True) or {}
+
+    required_fields = [
+        "address",
+        "price",
+        "features",
+        "agent_name",
+        "agent_phone",
+        "agent_email",
+    ]
+
+    for field in required_fields:
+        if field not in data:
+            return jsonify({"error": f"Missing field: {field}"}), 400
+
+    result = generate_flyer({key: data[key] for key in required_fields})
+    return jsonify({
+        "subject": result.get("subject", ""),
+        "html_body": result.get("html_body", ""),
+    })

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -5,3 +5,44 @@ def test_index():
     response = tester.get('/')
     assert response.status_code == 200
     assert response.get_json() == {'message': 'Hello, World!'}
+
+
+def test_generate_flyer_success(monkeypatch):
+    tester = app.test_client()
+
+    payload = {
+        "address": "123 Main St",
+        "price": "$100",
+        "features": ["a", "b"],
+        "agent_name": "Agent",
+        "agent_phone": "123",
+        "agent_email": "a@b.com",
+    }
+
+    expected = {"subject": "hi", "html_body": "<p>body</p>"}
+
+    def fake_generate_flyer(data):
+        assert data == payload
+        return expected
+
+    monkeypatch.setattr("app.routes.generate_flyer", fake_generate_flyer)
+
+    response = tester.post("/generate-flyer", json=payload)
+    assert response.status_code == 200
+    assert response.get_json() == expected
+
+
+def test_generate_flyer_missing_field():
+    tester = app.test_client()
+    payload = {
+        "address": "123 Main St",
+        "price": "$100",
+        "features": ["a", "b"],
+        "agent_name": "Agent",
+        "agent_phone": "123",
+        # missing agent_email
+    }
+
+    response = tester.post("/generate-flyer", json=payload)
+    assert response.status_code == 400
+    assert "error" in response.get_json()


### PR DESCRIPTION
## Summary
- create POST /generate-flyer endpoint
- validate JSON fields and call `generate_flyer`
- return subject and html_body
- test success and validation failure paths

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883efce7c5c832199af1042f67f7d10