### PR TITLE
Improve OpenAI error handling

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -27,7 +27,12 @@ def generate_flyer_route():
         if field not in data:
             return jsonify({"error": f"Missing field: {field}"}), 400
 
-    result = generate_flyer({key: data[key] for key in required_fields})
+    try:
+        result = generate_flyer({key: data[key] for key in required_fields})
+    except RuntimeError as exc:
+        return jsonify({"error": str(exc)}), 502
+    except Exception:
+        return jsonify({"error": "Internal server error"}), 500
     return jsonify({
         "subject": result.get("subject", ""),
         "html_body": result.get("html_body", ""),

--- a/app/utils/openai_client.py
+++ b/app/utils/openai_client.py
@@ -2,12 +2,33 @@
 
 import json
 import openai
+from openai import OpenAIError
 
 
 def chat_completion(messages, model="gpt-3.5-turbo", **kwargs):
-    """Send a chat completion request."""
-    response = openai.ChatCompletion.create(model=model, messages=messages, **kwargs)
-    return response
+    """Send a chat completion request.
+
+    Parameters
+    ----------
+    messages : list
+        Chat messages to send to the API.
+    model : str, optional
+        The model name to use.
+
+    Returns
+    -------
+    Any
+        The API response object.
+
+    Raises
+    ------
+    RuntimeError
+        If the OpenAI API request fails.
+    """
+    try:
+        return openai.ChatCompletion.create(model=model, messages=messages, **kwargs)
+    except OpenAIError as exc:
+        raise RuntimeError(f"OpenAI API request failed: {exc}") from exc
 
 
 def generate_flyer(data: dict) -> dict:
@@ -55,7 +76,12 @@ def generate_flyer(data: dict) -> dict:
 
     messages = [{"role": "user", "content": prompt}]
 
-    response = chat_completion(messages)
+    try:
+        response = chat_completion(messages)
+    except RuntimeError:
+        # Propagate API errors to the caller
+        raise
+
     content = response["choices"][0]["message"]["content"]
 
     try:

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -46,3 +46,24 @@ def test_generate_flyer_missing_field():
     response = tester.post("/generate-flyer", json=payload)
     assert response.status_code == 400
     assert "error" in response.get_json()
+
+
+def test_generate_flyer_openai_error(monkeypatch):
+    tester = app.test_client()
+    payload = {
+        "address": "123 Main St",
+        "price": "$100",
+        "features": ["a", "b"],
+        "agent_name": "Agent",
+        "agent_phone": "123",
+        "agent_email": "a@b.com",
+    }
+
+    def fake_generate_flyer(data):
+        raise RuntimeError("OpenAI API request failed: boom")
+
+    monkeypatch.setattr("app.routes.generate_flyer", fake_generate_flyer)
+
+    response = tester.post("/generate-flyer", json=payload)
+    assert response.status_code == 502
+    assert "error" in response.get_json()


### PR DESCRIPTION
## Summary
- handle `OpenAIError` in utility helper
- return 502 Bad Gateway when flyer generation fails
- test error branch for `/generate-flyer`

## Testing
- `pip install -r requirements.txt`
- `pip install python-dotenv`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6884090885548321b1a5577615eea327