### PR TITLE
Add flyer template rendering

### DIFF
--- a/app/templates/flyer_template.html
+++ b/app/templates/flyer_template.html
@@ -1,0 +1,18 @@
+<html>
+  <body style="font-family: Arial, sans-serif; line-height: 1.6;">
+    <h2 style="color: #2e6da4;">🏠 New Listing Alert</h2>
+    <p><strong>📍 Address:</strong> {{ address }}</p>
+    <p><strong>💰 Price:</strong> {{ price }}</p>
+    <p><strong>✨ Features:</strong></p>
+    <ul>
+      {% for feature in features %}
+        <li>{{ feature }}</li>
+      {% endfor %}
+    </ul>
+    <p>For more information, contact:</p>
+    <p><strong>{{ agent_name }}</strong><br>
+    📞 {{ agent_phone }}<br>
+    📧 {{ agent_email }}</p>
+  </body>
+</html>
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask>=2.3
 flask-cors
 openai>=1
+python-dotenv


### PR DESCRIPTION
## Summary
- add Jinja2 template for flyers under `app/templates`
- simplify `/generate-flyer` route to render the template
- update tests for new flyer rendering
- include `python-dotenv` in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68841af303bc8321b2ed39046b4a3e6f