### PR TITLE
Use dotenv for config

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,12 +1,9 @@
 from flask import Flask
 from flask_cors import CORS
 from dotenv import load_dotenv
-import os
 
-load_dotenv()  # loads variables from .env into os.environ
-
-# Now access it like:
-api_key = os.getenv("OPENAI_API_KEY")
+# Load environment variables from a .env file if present.
+load_dotenv()
 
 
 app = Flask(__name__)

--- a/app/utils/mailer.py
+++ b/app/utils/mailer.py
@@ -1,13 +1,24 @@
 import smtplib
+import os
 from email.message import EmailMessage
 
 
-SMTP_HOST = "smtp.example.com"
-SMTP_PORT = 587
-SENDER_EMAIL = "noreply@example.com"
+SMTP_HOST = os.getenv("SMTP_HOST")
+SMTP_PORT = os.getenv("SMTP_PORT")
+SMTP_EMAIL = os.getenv("SMTP_EMAIL")
+SMTP_PASSWORD = os.getenv("SMTP_PASSWORD")
+
+if not all([SMTP_HOST, SMTP_PORT, SMTP_EMAIL, SMTP_PASSWORD]):
+    raise RuntimeError(
+        "Missing required SMTP configuration environment variables"
+    )
+
+SMTP_PORT = int(SMTP_PORT)
+
+SENDER_EMAIL = SMTP_EMAIL
 RECIPIENT_EMAIL = "recipient@example.com"
-USERNAME = "noreply@example.com"
-PASSWORD = "examplepassword"
+USERNAME = SMTP_EMAIL
+PASSWORD = SMTP_PASSWORD
 
 
 def send_flyer(subject: str, html_body: str) -> None:

--- a/app/utils/openai_client.py
+++ b/app/utils/openai_client.py
@@ -2,12 +2,13 @@
 
 import json
 import os
-from dotenv import load_dotenv
 from openai import OpenAI, OpenAIError
 
-load_dotenv()
+api_key = os.getenv("OPENAI_API_KEY")
+if not api_key:
+    raise RuntimeError("Missing OPENAI_API_KEY environment variable")
 
-client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+client = OpenAI(api_key=api_key)
 
 
 def chat_completion(messages, model="gpt-3.5-turbo", **kwargs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,5 +3,9 @@ import os
 
 # Ensure the OpenAI client can initialize during tests
 os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("SMTP_HOST", "smtp.test")
+os.environ.setdefault("SMTP_PORT", "25")
+os.environ.setdefault("SMTP_EMAIL", "sender@test.com")
+os.environ.setdefault("SMTP_PASSWORD", "password")
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))


### PR DESCRIPTION
## Summary
- load environment from `.env`
- fail loudly when required environment variables are missing
- adjust tests for environment vars

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688421da34fc8321bf8e13f308d6df01