### PR TITLE
Add SMTP email sending in /generate-flyer route

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from app import app
 
 
@@ -18,12 +20,17 @@ def test_generate_flyer_success():
         "agent_name": "Agent",
         "agent_phone": "123",
         "agent_email": "a@b.com",
+        "recipient_email": "recipient@test.com",
+        "subject": "Beautiful Home in 123 Main St – Don’t Miss Out!",
     }
 
-    response = tester.post("/generate-flyer", json=payload)
+    with patch("app.routes.smtplib.SMTP") as mock_smtp:
+        response = tester.post("/generate-flyer", json=payload)
+
     assert response.status_code == 200
     data = response.get_json()
-    assert data["subject"] == "Beautiful Home in 123 Main St – Don’t Miss Out!"
+    assert data["status"] == "Email sent successfully"
+    assert data["subject"] == payload["subject"]
     assert "<li>a</li>" in data["html_body"]
     assert "<li>b</li>" in data["html_body"]
     assert "Agent" in data["html_body"]
@@ -36,9 +43,12 @@ def test_generate_flyer_defaults():
         "price": "$1",
     }
 
-    response = tester.post("/generate-flyer", json=payload)
+    with patch("app.routes.smtplib.SMTP") as mock_smtp:
+        response = tester.post("/generate-flyer", json=payload)
+
     assert response.status_code == 200
     data = response.get_json()
+    assert data["status"] == "Email sent successfully"
     assert data["subject"] == "Beautiful Home in 1 Test Way – Don’t Miss Out!"
     assert "<ul>" in data["html_body"]
 


### PR DESCRIPTION
## Summary
- update `/generate-flyer` to send the rendered flyer via SMTP using credentials from environment variables
- include status in JSON response and handle SMTP errors
- adjust tests to mock SMTP and expect new response

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688453945c6c83219bbce73ffad0779e