### PR TITLE
Add flyer form and form handling

### DIFF
--- a/app/templates/flyer_form.html
+++ b/app/templates/flyer_form.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+<head>
+    <title>Generate Flyer</title>
+</head>
+<body>
+    {% if message %}
+    <p>{{ message }}</p>
+    {% endif %}
+    <form method="post" action="/generate-flyer">
+        <label>Address:<br><input type="text" name="address" required></label><br>
+        <label>Price:<br><input type="text" name="price" required></label><br>
+        <label>Features:<br><textarea name="features" rows="5"></textarea></label><br>
+        <label>Agent Name:<br><input type="text" name="agent_name" required></label><br>
+        <label>Agent Phone:<br><input type="text" name="agent_phone"></label><br>
+        <label>Agent Email:<br><input type="email" name="agent_email" required></label><br>
+        <label>Subject:<br><input type="text" name="subject"></label><br>
+        <button type="submit">Send Flyer</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `/flyer-form` route and template for submitting flyer details
- handle form submissions in `/generate-flyer`
- return success or error messages when submitting from form
- test the new route and form workflow
- read payload from `test_payload.json` in tests and handle features passed as string

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688468e1156083218e91d60c3636b680