### PR TITLE
Add root form route

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -13,7 +13,8 @@ from . import app
 
 @app.route('/')
 def index():
-    return jsonify({'message': 'Hello, World!'})
+    """Render the main flyer form."""
+    return render_template("form.html")
 
 
 @app.route('/flyer-form')

--- a/app/templates/form.html
+++ b/app/templates/form.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+<head>
+    <title>Flyer Details</title>
+</head>
+<body>
+    <form method="post" action="/generate-flyer">
+        <label>Address:<br><input type="text" name="address" required></label><br>
+        <label>Price:<br><input type="text" name="price" required></label><br>
+        <label>Features:<br><textarea name="features" rows="5"></textarea></label><br>
+        <label>Agent Name:<br><input type="text" name="agent_name" required></label><br>
+        <label>Agent Phone:<br><input type="text" name="agent_phone"></label><br>
+        <label>Agent Email:<br><input type="email" name="agent_email" required></label><br>
+        <label>Recipient Email:<br><input type="email" name="recipient_email" required></label><br>
+        <button type="submit">Generate Flyer</button>
+    </form>
+</body>
+</html>

--- a/test_payload.json
+++ b/test_payload.json
@@ -1,5 +1,14 @@
 {
-  "subject": "Test Email",
-  "recipient_email": "limblicious@gmail.com",
-  "html_body": "This is a test email from your Flask app."
+  "address": "123 Elm Street, San Jose, CA",
+  "price": "$950,000",
+  "features": [
+    "3 Bedrooms, 2 Bathrooms",
+    "Modern open kitchen",
+    "Large backyard with patio",
+    "Near Caltrain",
+    "Attached garage"
+  ],
+  "agent_name": "Jonathan Lee",
+  "agent_phone": "555-123-4567",
+  "agent_email": "jonathan@homes.com"
 }

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -8,7 +8,7 @@ def test_index():
     tester = app.test_client()
     response = tester.get('/')
     assert response.status_code == 200
-    assert response.get_json() == {'message': 'Hello, World!'}
+    assert b'<form' in response.data
 
 
 def test_flyer_form_route():


### PR DESCRIPTION
## Summary
- show form.html on the `/` route
- include new form template for flyer generation
- expand test payload back to full flyer data
- update tests for new `/` route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68846f272554832194a637d20ddfbd47